### PR TITLE
[Hotfix] Wrong prometheus file name in creating monitoring script

### DIFF
--- a/01_monitoring/grafana-prometheus/grafana_builder.sh
+++ b/01_monitoring/grafana-prometheus/grafana_builder.sh
@@ -14,7 +14,7 @@ do
 done
 
 # Check before
-PROMETHUS_YAML="promethus.yml"
+PROMETHUS_YAML="prometheus.yml"
 if [ ! -f "$PROMETHUS_YAML" ]; then
     echo "$PROMETHUS_YAML not exists."
     echo "Please create a $PROMETHUS_YAML using the template file."


### PR DESCRIPTION
# ISSUE

Wrong string; prometheus yaml file name in creating grafana and prometheus monitoring script

# TASK

Modify script
1. 01_monitoring/grafana-prometheus/grafana_builder.sh
    17 row `promethus.yml` -> `prometheus.yml`

# TEST

- [x] Is it possible to create prometheus module in develop environment?
       (It will be attach to prod environment,  because it is hotfix task )